### PR TITLE
Update Battering_Ram.vue

### DIFF
--- a/pages/units/Battering_Ram.vue
+++ b/pages/units/Battering_Ram.vue
@@ -10,7 +10,7 @@
           <p>
             <b>輕型衝撞車</b
             >是世紀帝國II遊戲中，沒有人駕駛卻可以講話的神奇軍事單位，它可以從<nuxt-link
-              to="/units//building/Siege_Workshop"
+              to="/building/Siege_Workshop"
               >攻城器製造所</nuxt-link
             >製造，對一般單位的<nuxt-link to="/elements/Attack"
               >攻擊力</nuxt-link


### PR DESCRIPTION
簡介連結至攻城器製造所之連結修正  
原文：`<nuxt-link to="/units//building/Siege_Workshop">`  
改為：`<nuxt-link to="/building/Siege_Workshop">`